### PR TITLE
Fix up application_name logic

### DIFF
--- a/app/models/global_alerts/alert.rb
+++ b/app/models/global_alerts/alert.rb
@@ -46,7 +46,7 @@ module GlobalAlerts
     delegate :present?, to: :html
 
     def active?(time: Time.zone.now, for_application: nil)
-      return false if for_application == application_name
+      return false if for_application != application_name
 
       return true if from.nil? && to.nil?
 


### PR DESCRIPTION
Part of #12
This PR fixes up the logic for `application_name`. 

Previous behavior: setting `application_name` would exclude an app from the global alert and set all other applications to use that message.

New behavior: settings `application_name` sets the alert for a specific app. Other applications will default to another message if provided.