### PR TITLE
Update deprecated Module#parent_name method

### DIFF
--- a/lib/global_alerts/engine.rb
+++ b/lib/global_alerts/engine.rb
@@ -7,7 +7,7 @@ module GlobalAlerts
     config.url = 'https://github.com/sul-dlss/global-alerts/raw/main/sul.yaml'
 
     initializer('global_alerts_default') do |app|
-      config.application_name ||= app.class.parent_name.underscore
+      config.application_name ||= app.class.module_parent_name.underscore
     end
   end
 end

--- a/lib/global_alerts/engine.rb
+++ b/lib/global_alerts/engine.rb
@@ -7,7 +7,8 @@ module GlobalAlerts
     config.url = 'https://github.com/sul-dlss/global-alerts/raw/main/sul.yaml'
 
     initializer('global_alerts_default') do |app|
-      config.application_name ||= app.class.module_parent_name.underscore
+      # parent_name is deprecated in Rails 6.1
+      config.application_name ||= app.class.respond_to?(:parent_name) ? app.class.parent_name.underscore : app.class.module_parent_name.underscore
     end
   end
 end


### PR DESCRIPTION
```
DEPRECATION WARNING: `Module#parent_name` has been renamed to `module_parent_name`. `parent_name` is deprecated and will be removed in Rails 6.1. (called from <top (required)> at /Users/cvilla/workbench/sul-bento-app/config/environment.rb:5)
```