### PR TITLE
Add a way to change the effective date/time used for global alerts

### DIFF
--- a/app/models/global_alerts/alert.rb
+++ b/app/models/global_alerts/alert.rb
@@ -6,6 +6,14 @@ module GlobalAlerts
 
     CACHE_KEY = 'global-alerts'
 
+    def self.global_alert_time
+      @global_alert_time || Time.zone.now
+    end
+
+    def self.global_alert_time=(time)
+      @global_alert_time = time
+    end
+
     def self.all
       return to_enum(:all) unless block_given?
 
@@ -25,7 +33,7 @@ module GlobalAlerts
       []
     end
 
-    def self.active(time = Time.zone.now)
+    def self.active(time = GlobalAlerts::Alert.global_alert_time)
       active_alert = all.find do |alert|
         alert.active?(time: time, for_application: GlobalAlerts::Engine.config.application_name)
       end

--- a/test/models/global-alerts/alert_test.rb
+++ b/test/models/global-alerts/alert_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class GlobalAlerts::Alert::Test < ActiveSupport::TestCase
+  test "it defaults to the current time" do
+    assert_in_delta Time.zone.now, GlobalAlerts::Alert.global_alert_time, 1
+  end
+
+  test "it can be set explicitly" do
+    t = Time.zone.now - 1.day
+    GlobalAlerts::Alert.global_alert_time = t
+
+    assert_equal t, GlobalAlerts::Alert.global_alert_time
+
+    GlobalAlerts::Alert.global_alert_time = nil
+  end
+end


### PR DESCRIPTION
to make it easier/possible to preview future alerts in dev environments