### PR TITLE
Delete MyLibrary PIN message

### DIFF
--- a/sul.yaml
+++ b/sul.yaml
@@ -1,12 +1,5 @@
 ---
 alerts:
-  - to: '2023-09-25T00:00:00-07:00'
-    application_name: MyLibrary
-    html: >
-      <p><strong>Stanford Libraries completed a major system upgrade on August 27.</strong></p>
-      <p>Users with proxy, fee or courtesy accounts (and log in with a PIN) need to update their PIN.
-      Select "Request a PIN" below to update.
-      </p>
   - to: '2023-08-29T00:00:00-07:00'
     application_name: sul_bento_app
     html: >


### PR DESCRIPTION
- Removes the global PIN alert message
- Replaced with "local alerts" via [this mylibrary PR](https://github.com/sul-dlss/mylibrary/pull/960)